### PR TITLE
feat: Implement Phase 1 - Audio Capture and Deepgram Streaming

### DIFF
--- a/intellijpa.xcodeproj/project.pbxproj
+++ b/intellijpa.xcodeproj/project.pbxproj
@@ -27,11 +27,28 @@
 		96A7EA4F2DDD45F200D57984 /* intellijpa.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = intellijpa.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		96A7EA5F2DDD45F500D57984 /* intellijpaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = intellijpaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		96A7EA692DDD45F500D57984 /* intellijpaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = intellijpaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		96A7EA7C2DDD45F500D57985 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		96A7EA7E2DDD45F500D57987 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = intellijpa/Info.plist; sourceTree = "<group>"; };
+		96A7EA7F2DDD45F500D57988 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AudioRecorder.swift; path = intellijpa/AudioRecorder.swift; sourceTree = "<group>"; };
+		96A7EA812DDD45F500D57990 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ContentView.swift; path = intellijpa/ContentView.swift; sourceTree = "<group>"; };
+		96A7EA822DDD45F500D57991 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Item.swift; path = intellijpa/Item.swift; sourceTree = "<group>"; };
+		96A7EA832DDD45F500D57992 /* intellijpaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = intellijpaApp.swift; path = intellijpa/intellijpaApp.swift; sourceTree = "<group>"; };
+		96A7EA872DDD45F500D57996 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = intellijpa/Assets.xcassets; sourceTree = "<group>"; };
+		96A7EA882DDD45F500D57997 /* intellijpa.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = intellijpa.entitlements; path = intellijpa/intellijpa.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		96A7EA512DDD45F200D57984 /* intellijpa */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
+			isa = PBXGroup;
+			children = (
+				96A7EA7F2DDD45F500D57988 /* AudioRecorder.swift */,
+				96A7EA7E2DDD45F500D57987 /* Info.plist */,
+				96A7EA812DDD45F500D57990 /* ContentView.swift */,
+				96A7EA822DDD45F500D57991 /* Item.swift */,
+				96A7EA832DDD45F500D57992 /* intellijpaApp.swift */,
+				96A7EA872DDD45F500D57996 /* Assets.xcassets */,
+				96A7EA882DDD45F500D57997 /* intellijpa.entitlements */,
+			);
 			path = intellijpa;
 			sourceTree = "<group>";
 		};
@@ -52,6 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96A7EA7D2DDD45F500D57986 /* AVFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -79,6 +97,7 @@
 				96A7EA622DDD45F500D57984 /* intellijpaTests */,
 				96A7EA6C2DDD45F500D57984 /* intellijpaUITests */,
 				96A7EA502DDD45F200D57984 /* Products */,
+				96A7EA7C2DDD45F500D57985 /* AVFoundation.framework */,
 			);
 			sourceTree = "<group>";
 		};
@@ -92,6 +111,13 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		96A7EA7D2DDD45F500D57986 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96A7EA7C2DDD45F500D57985 /* AVFoundation.framework */; };
+		96A7EA802DDD45F500D57989 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A7EA7F2DDD45F500D57988 /* AudioRecorder.swift */; };
+		96A7EA842DDD45F500D57993 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A7EA812DDD45F500D57990 /* ContentView.swift */; };
+		96A7EA852DDD45F500D57994 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A7EA822DDD45F500D57991 /* Item.swift */; };
+		96A7EA862DDD45F500D57995 /* intellijpaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A7EA832DDD45F500D57992 /* intellijpaApp.swift */; };
+		96A7EA892DDD45F500D57998 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 96A7EA872DDD45F500D57996 /* Assets.xcassets */; };
+		96A7EA8A2DDD45F500D57999 /* intellijpa.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 96A7EA882DDD45F500D57997 /* intellijpa.entitlements */; };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -212,6 +238,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96A7EA892DDD45F500D57998 /* Assets.xcassets in Resources */,
+				96A7EA8A2DDD45F500D57999 /* intellijpa.entitlements in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -236,6 +264,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96A7EA802DDD45F500D57989 /* AudioRecorder.swift in Sources */,
+				96A7EA842DDD45F500D57993 /* ContentView.swift in Sources */,
+				96A7EA852DDD45F500D57994 /* Item.swift in Sources */,
+				96A7EA862DDD45F500D57995 /* intellijpaApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -398,6 +430,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = intellijpa/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -424,6 +457,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = intellijpa/Info.plist;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/intellijpa/AudioRecorder.swift
+++ b/intellijpa/AudioRecorder.swift
@@ -1,0 +1,170 @@
+import AVFoundation
+import OSLog // Import OSLog
+
+class AudioRecorder {
+    private var audioEngine: AVAudioEngine?
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "intellijpa", category: "AudioRecorder")
+    private var audioFile: AVAudioFile?
+    // No specific tap needed for this implementation as we capture the whole file.
+    // private var recordingTap: AVAudioNodeTapBlock? // Removed as direct file writing is used
+
+    func startRecording(completion: @escaping (String?) -> Void) {
+        logger.info("Attempting to start recording...")
+        AVAudioSession.sharedInstance().requestRecordPermission { granted in
+            if !granted {
+                self.logger.error("Microphone permission denied.")
+                completion("Microphone permission denied.")
+                return
+            }
+
+            self.audioEngine = AVAudioEngine()
+            guard let audioEngine = self.audioEngine else {
+                self.logger.error("AudioEngine initialization failed.")
+                completion("Audio engine could not be initialized.")
+                return
+            }
+
+            let inputNode = audioEngine.inputNode
+            guard let recordingFormat = AVAudioFormat(commonFormat: .pcmFormatInt16, sampleRate: 16000, channels: 1, interleaved: true) else {
+                self.logger.error("Failed to create recording format.")
+                completion("Audio format conversion failed.")
+                return
+            }
+            
+            let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            let audioFilename = documentsPath.appendingPathComponent("recording.wav")
+
+            do {
+                self.audioFile = try AVAudioFile(forWriting: audioFilename, settings: recordingFormat.settings, commonFormat: recordingFormat.commonFormat, interleaved: recordingFormat.isInterleaved)
+            } catch {
+                self.logger.error("Error creating audio file: \(error.localizedDescription)")
+                completion("Failed to create audio file: \(error.localizedDescription)")
+                return
+            }
+            
+            inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
+                do {
+                    try self.audioFile?.write(from: buffer)
+                } catch {
+                    self.logger.error("Error writing buffer to audio file: \(error.localizedDescription)")
+                    // This error is harder to propagate to completion as it happens in a closure.
+                    // Consider internal state update or alternative error reporting if critical during recording.
+                }
+            }
+
+            do {
+                try audioEngine.prepare()
+                try audioEngine.start()
+                self.logger.info("Recording started, writing to: \(audioFilename.path)")
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5.0) {
+                    self.stopRecording(audioEngine: audioEngine, inputNode: inputNode, audioFilename: audioFilename, originalCompletion: completion)
+                }
+            } catch {
+                self.logger.error("Error starting audio engine: \(error.localizedDescription)")
+                if FileManager.default.fileExists(atPath: audioFilename.path) {
+                    try? FileManager.default.removeItem(at: audioFilename)
+                }
+                completion("Audio recording setup failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func stopRecording(audioEngine: AVAudioEngine, inputNode: AVAudioInputNode, audioFilename: URL, originalCompletion: @escaping (String?) -> Void) {
+        audioEngine.stop()
+        inputNode.removeTap(onBus: 0)
+        self.audioFile = nil // Close the file to ensure data is flushed.
+        logger.info("Recording stopped. File saved at: \(audioFilename.path)")
+
+        do {
+            let audioData = try Data(contentsOf: audioFilename)
+            try FileManager.default.removeItem(at: audioFilename)
+            logger.info("Successfully read and deleted temporary audio file.")
+            
+            sendAudioDataToBackend(audioData: audioData, completion: originalCompletion)
+            
+        } catch {
+            logger.error("Error reading or deleting audio file: \(error.localizedDescription)")
+            originalCompletion("Failed to process recorded audio file: \(error.localizedDescription)")
+        }
+        self.audioEngine = nil
+    }
+
+    private func sendAudioDataToBackend(audioData: Data, completion: @escaping (String?) -> Void) {
+        guard let url = URL(string: "http://127.0.0.1:8000/transcribe") else {
+            logger.error("Invalid backend URL string.")
+            completion("Internal error: Invalid backend URL.")
+            return
+        }
+        logger.info("Initiating request to backend: \(url.absoluteString)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let boundary = "Boundary-\(UUID().uuidString)"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(audioData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                self.logger.error("Network request error: \(error.localizedDescription)")
+                completion("Network error: \(error.localizedDescription)")
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                self.logger.error("Invalid response from server (not HTTPURLResponse).")
+                completion("Server error: Invalid response type.")
+                return
+            }
+            
+            let rawResponseString = String(data: data ?? Data(), encoding: .utf8) ?? "No response body or non-UTF8."
+            self.logger.info("Raw response from backend (status: \(httpResponse.statusCode)): \(rawResponseString)")
+
+            guard (200...299).contains(httpResponse.statusCode) else {
+                self.logger.error("Backend returned error status: \(httpResponse.statusCode). Body: \(rawResponseString)")
+                completion("Backend error: Status \(httpResponse.statusCode). \(rawResponseString)")
+                return
+            }
+            
+            guard let responseData = data, !responseData.isEmpty else {
+                self.logger.error("No data received from backend or data is empty.")
+                completion("Server error: No data received.")
+                return
+            }
+
+            do {
+                if let jsonResponse = try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any] {
+                    if let transcription = jsonResponse["transcription"] as? String, !transcription.isEmpty {
+                        self.logger.info("Successfully parsed transcription: \(transcription)")
+                        completion(transcription)
+                    } else if let backendError = jsonResponse["error"] as? String, !backendError.isEmpty {
+                        self.logger.error("Backend returned an error message: \(backendError)")
+                        completion("Backend error: \(backendError)")
+                    } else if let transcription = jsonResponse["transcription"] as? String, transcription.isEmpty {
+                        self.logger.info("Transcription is empty (no speech detected).")
+                        completion("") // Empty string indicates no speech detected
+                    }
+                    else {
+                        self.logger.error("Failed to parse JSON or required fields not found. JSON: \(jsonResponse)")
+                        completion("Server error: Unexpected response format.")
+                    }
+                } else {
+                     self.logger.error("JSON response was not a dictionary. Raw: \(rawResponseString)")
+                     completion("Server error: Malformed JSON response.")
+                }
+            } catch {
+                self.logger.error("JSON parsing error: \(error.localizedDescription). Raw response: \(rawResponseString)")
+                completion("Server error: Failed to parse response. \(error.localizedDescription)")
+            }
+        }
+        task.resume()
+    }
+}

--- a/intellijpa/ContentView.swift
+++ b/intellijpa/ContentView.swift
@@ -6,54 +6,83 @@
 //
 
 import SwiftUI
-import SwiftData
+// import SwiftData // SwiftData is not used in this modified version
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Query private var items: [Item]
+    // @Environment(\.modelContext) private var modelContext // SwiftData not used
+    // @Query private var items: [Item] // SwiftData not used
+    
+    @State private var transcribedText: String = "Press record to transcribe..."
+    private var audioRecorder = AudioRecorder()
 
     var body: some View {
-        NavigationSplitView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))")
-                    } label: {
-                        Text(item.timestamp, format: Date.FormatStyle(date: .numeric, time: .standard))
+        NavigationView { // Using NavigationView for a title bar
+            VStack {
+                Text(transcribedText)
+                    .padding()
+                    .lineLimit(nil) // Allow multiple lines
+                    .frame(minHeight: 100) // Give some space for text
+
+                Button(action: {
+                    self.transcribedText = "Recording..."
+                    audioRecorder.startRecording { transcriptionResult in
+                        DispatchQueue.main.async {
+                            if let result = transcriptionResult {
+                                if result.isEmpty {
+                                    // Case where backend returned an empty transcription string,
+                                    // implying no speech was detected or the audio was silent.
+                                    self.transcribedText = "No speech detected in the audio."
+                                } else if result.starts(with: "Microphone permission denied") ||
+                                          result.starts(with: "Audio engine could not be initialized") ||
+                                          result.starts(with: "Audio format conversion failed") ||
+                                          result.starts(with: "Failed to create audio file") ||
+                                          result.starts(with: "Audio recording setup failed") ||
+                                          result.starts(with: "Failed to process recorded audio file") ||
+                                          result.starts(with: "Internal error: Invalid backend URL") ||
+                                          result.starts(with: "Network error") ||
+                                          result.starts(with: "Server error") ||
+                                          result.starts(with: "Backend error") {
+                                    // Specific error messages passed from AudioRecorder
+                                    self.transcribedText = "Error: \(result)"
+                                }
+                                else {
+                                    // Successful transcription
+                                    self.transcribedText = result
+                                }
+                            } else {
+                                // This case implies a more fundamental issue where transcriptionResult is nil,
+                                // which our improved AudioRecorder tries to avoid by passing specific error strings.
+                                // However, as a fallback:
+                                self.transcribedText = "Transcription failed. An unexpected error occurred."
+                            }
+                        }
                     }
-                }
-                .onDelete(perform: deleteItems)
-            }
-            .navigationSplitViewColumnWidth(min: 180, ideal: 200)
-            .toolbar {
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
+                }) {
+                    Label("Record Audio", systemImage: "mic.fill")
+                        .padding()
                 }
             }
-        } detail: {
-            Text("Select an item")
+            .navigationTitle("Audio Transcriber") // Sets a title for the view
         }
     }
 
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(timestamp: Date())
-            modelContext.insert(newItem)
-        }
-    }
+    // private func addItem() { // SwiftData addItem removed
+    //     withAnimation {
+    //         let newItem = Item(timestamp: Date())
+    //         modelContext.insert(newItem)
+    //     }
+    // }
 
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
-            }
-        }
-    }
+    // private func deleteItems(offsets: IndexSet) { // SwiftData deleteItems removed
+    //     withAnimation {
+    //         for index in offsets {
+    //             modelContext.delete(items[index])
+    //         }
+    //     }
+    // }
 }
 
 #Preview {
     ContentView()
-        .modelContainer(for: Item.self, inMemory: true)
+    // .modelContainer(for: Item.self, inMemory: true) // SwiftData modelContainer removed
 }

--- a/intellijpa/Info.plist
+++ b/intellijpa/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app requires microphone access to record audio.</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/python_backend/main.py
+++ b/python_backend/main.py
@@ -1,0 +1,168 @@
+import os
+from fastapi import FastAPI, File, UploadFile, HTTPException
+from deepgram import (
+    DeepgramClient,
+    DeepgramClientOptions,
+    LiveTranscriptionEvents,
+    LiveOptions,
+    Microphone,
+    DeepgramError, # Import DeepgramError for specific exception handling
+)
+from dotenv import load_dotenv
+import logging # For more structured logging
+
+load_dotenv()
+
+# Setup basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# For local testing, replace with your actual Deepgram API Key
+DEEPGRAM_API_KEY = os.getenv("DEEPGRAM_API_KEY", "YOUR_DEEPGRAM_API_KEY")
+
+app = FastAPI()
+
+@app.post("/transcribe")
+async def transcribe_audio(file: UploadFile = File(...)):
+    logging.info(f"/transcribe endpoint called with file: {file.filename}")
+    if not DEEPGRAM_API_KEY or DEEPGRAM_API_KEY == "YOUR_DEEPGRAM_API_KEY":
+        logging.error("Deepgram API key not configured.")
+        raise HTTPException(status_code=500, detail="Deepgram API key not configured.")
+
+    dg_connection = None  # Initialize to ensure it's defined for finally block
+    transcription_result = ""
+    deepgram_error_message = None # To store specific Deepgram errors
+
+    try:
+        # Initialize Deepgram client
+        config = DeepgramClientOptions(
+            verbose=0, 
+            options={"keepalive": "true"}
+        )
+        deepgram: DeepgramClient = DeepgramClient(DEEPGRAM_API_KEY, config)
+
+        # Create a live transcription connection
+        dg_connection = deepgram.listen.live.v("1")
+
+        # Define event handlers
+        def on_open(self, open, **kwargs):
+            logging.info(f"Deepgram connection opened: {open}")
+
+        
+        def on_message(self, result, **kwargs):
+            nonlocal transcription_result
+            sentence = result.channel.alternatives[0].transcript
+            if len(sentence) > 0:
+                transcription_result += (" " + sentence if transcription_result else sentence)
+            logging.info(f"Deepgram interim transcript: {sentence}")
+
+
+        def on_metadata(self, metadata, **kwargs):
+            logging.info(f"Deepgram metadata: {metadata}")
+
+        def on_speech_started(self, speech_started, **kwargs):
+            logging.info(f"Deepgram speech started: {speech_started}")
+            pass
+
+        def on_utterance_end(self, utterance_end, **kwargs):
+            logging.info(f"Deepgram utterance ended: {utterance_end}")
+            pass 
+
+        def on_close(self, close, **kwargs):
+            logging.info(f"Deepgram connection closed: {close}")
+            pass
+
+        def on_error(self, error, **kwargs):
+            nonlocal deepgram_error_message
+            error_message = str(error.get('message', 'Unknown Deepgram error'))
+            logging.error(f"Deepgram error: {error_message}")
+            deepgram_error_message = error_message # Store the error message
+
+        def on_unhandled(self, unhandled, **kwargs):
+            logging.warning(f"Deepgram unhandled event: {unhandled}")
+            pass
+
+        dg_connection.on(LiveTranscriptionEvents.Open, on_open)
+        dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
+        dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
+        dg_connection.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
+        dg_connection.on(LiveTranscriptionEvents.UtteranceEnd, on_utterance_end)
+        dg_connection.on(LiveTranscriptionEvents.Close, on_close)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error) # Make sure this is correctly assigned
+        dg_connection.on(LiveTranscriptionEvents.Unhandled, on_unhandled)
+        
+        # Define live transcription options
+        options: LiveOptions = LiveOptions(
+            model="nova-2",
+            language="en-US",
+            # Apply encoding and sample rate if needed, otherwise defaults
+            # encoding="linear16", # Example
+            # sample_rate=16000,  # Example
+            interim_results=True,
+            utterance_end_ms="1000",
+            vad_events=True,
+        )
+
+        # Start the connection
+        logging.info("Attempting to start Deepgram connection.")
+        if not await dg_connection.start(options): # dg_connection.start can be awaited
+            logging.error("Failed to start Deepgram connection.")
+            # The on_error handler should catch specific connection errors from Deepgram.
+            # If start itself fails without an error event, this is a fallback.
+            raise HTTPException(status_code=500, detail=deepgram_error_message or "Failed to connect to Deepgram (initiation phase).")
+
+        logging.info("Deepgram connection started. Streaming audio data...")
+        # Read the uploaded file in chunks and send to Deepgram
+        chunk_size = 4096
+        while True:
+            data = await file.read(chunk_size)
+            if not data:
+                break
+            dg_connection.send(data)
+        
+        logging.info("Finished sending audio data to Deepgram. Closing connection.")
+        # Signal the end of the audio stream
+        await dg_connection.finish() 
+
+        # Wait for a short period for events to process, especially Close and final Transcript.
+        import asyncio
+        await asyncio.sleep(2) # This is a pragmatic delay. Robust solutions might use asyncio.Event.
+
+        logging.info(f"Final transcription result: '{transcription_result}'")
+        if deepgram_error_message:
+            logging.error(f"Sending error response to Swift app: {deepgram_error_message}")
+            return {"transcription": "", "error": f"Deepgram error: {deepgram_error_message}"}
+        elif not transcription_result: # No transcription and no specific DG error
+             logging.warning("No transcription received from Deepgram, and no specific Deepgram error was caught.")
+             return {"transcription": "", "error": "No speech detected or empty audio."} # More specific
+        
+        logging.info("Sending successful transcription response to Swift app.")
+        return {"transcription": transcription_result}
+
+    except DeepgramError as e: # Specific Deepgram SDK errors
+        logging.error(f"Deepgram SDK error: {e}")
+        if dg_connection and dg_connection.is_connected():
+            await dg_connection.finish()
+        error_detail = f"Deepgram API error: {str(e)}"
+        # Check for common error types if possible, e.g., auth by inspecting str(e) or specific exception types if available
+        if "auth" in str(e).lower(): # Simplistic check
+            error_detail = "Deepgram authentication error. Check API Key."
+        raise HTTPException(status_code=500, detail=error_detail)
+    except HTTPException as e:
+        # Re-raise HTTPExceptions to be handled by FastAPI directly
+        logging.error(f"HTTPException: {e.detail}")
+        raise e
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}", exc_info=True) # Log full traceback
+        if dg_connection and dg_connection.is_connected():
+            await dg_connection.finish()
+        raise HTTPException(status_code=500, detail=f"An unexpected server error occurred: {str(e)}")
+    finally:
+        # Ensure connection is closed if it was opened and is still connected
+        if dg_connection and dg_connection.is_connected():
+            logging.info("Ensuring Deepgram connection is closed in finally block.")
+            await dg_connection.finish()
+
+if __name__ == "__main__":
+    import uvicorn
+    # Note: Uvicorn is used for development. For production, consider a more robust ASGI server.
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/python_backend/requirements.txt
+++ b/python_backend/requirements.txt
@@ -1,0 +1,4 @@
+deepgram-sdk>=3.0.0
+fastapi
+uvicorn
+python-multipart


### PR DESCRIPTION
This commit includes the initial setup for the MacVoice Assistant MVP, focusing on Phase 1: Audio Capture and Deepgram Streaming.

Key features implemented:
- **Project Structure:**
    - Created `python_backend` directory for the FastAPI server.
    - Added `AVFoundation.framework` to the Xcode project.
- **Swift Audio Capture (`intellijpa/AudioRecorder.swift`):**
    - Captures 5 seconds of audio using `AVAudioEngine`.
    - Configured for mono, 16kHz PCM audio.
    - Handles microphone permissions (NSMicrophoneUsageDescription added to Info.plist).
- **Python Backend (`python_backend/main.py`):**
    - FastAPI server with a `/transcribe` endpoint.
    - Receives audio file uploads.
    - Streams audio to Deepgram using the `deepgram-sdk`.
    - Returns transcription as JSON.
    - Placeholder for Deepgram API key.
- **Frontend-Backend Integration:**
    - Swift app sends audio data to the Python backend via HTTP POST.
    - Swift app receives and displays the transcription or error messages.
- **UI (`intellijpa/ContentView.swift`):**
    - Basic UI with a "Record Audio" button.
    - Displays transcribed text or relevant error/status messages.
- **Error Handling and Logging:**
    - Implemented os_log in Swift and logging in Python.
    - More descriptive error messages for recording, network, and transcription failures.

The application now allows you to record audio, send it to a local Python backend, have it transcribed by Deepgram, and see the result in the UI. This completes the planned work for "Phase 1: Audio capture + Deepgram streaming setup." Further testing by you is pending.